### PR TITLE
feat(gnodev) cache path and notify conflict path

### DIFF
--- a/contribs/gnodev/pkg/cachepath/cache_path_manual_deploy.go
+++ b/contribs/gnodev/pkg/cachepath/cache_path_manual_deploy.go
@@ -1,0 +1,30 @@
+package cachepath
+
+import (
+	"sync"
+)
+
+type CachePath struct {
+	data map[string]bool
+	mu   sync.RWMutex
+}
+
+var cache *CachePath
+
+func init() {
+	cache = &CachePath{
+		data: make(map[string]bool),
+	}
+}
+
+func Set(key string) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.data[key] = true
+}
+
+func Get(key string) bool {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	return cache.data[key]
+}

--- a/contribs/gnodev/pkg/emitter/server.go
+++ b/contribs/gnodev/pkg/emitter/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/events"
 	"github.com/gorilla/websocket"
 )

--- a/contribs/gnodev/pkg/emitter/server.go
+++ b/contribs/gnodev/pkg/emitter/server.go
@@ -105,6 +105,8 @@ func (s *Server) logEvent(evt events.Event) {
 		logEvt = string(rawEvt)
 
 		if evt.Type() == events.EvtTxResult {
+
+			// Temporary structure definition
 			type TxMsg struct {
 				Package struct {
 					Path string `json:"path"`
@@ -117,13 +119,15 @@ func (s *Server) logEvent(evt events.Event) {
 			type TxResultJSON struct {
 				Tx Tx `json:"tx"`
 			}
-
+			// Unmarshal the JSON data into the temporary structure
 			var txResult TxResultJSON
 			if err := json.Unmarshal(rawEvt, &txResult); err == nil && len(txResult.Tx.Msg) > 0 {
 				packagePath := txResult.Tx.Msg[0].Package.Path
 				packageName := txResult.Tx.Msg[0].Package.Name
 				s.logger.Info("User addPkg ", "name", packageName,
 					"path", packagePath)
+
+				// cache path
 				cachepath.Set(packagePath)
 			} else {
 				s.logger.Warn("Failed to parse package path or no messages found", "error", err)

--- a/contribs/gnodev/pkg/emitter/server.go
+++ b/contribs/gnodev/pkg/emitter/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+	"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/events"
 	"github.com/gorilla/websocket"
 )

--- a/contribs/gnodev/pkg/packages/loader_test.go
+++ b/contribs/gnodev/pkg/packages/loader_test.go
@@ -3,6 +3,7 @@ package packages
 import (
 	"testing"
 
+	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,4 +81,34 @@ func TestLoader_Glob(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolver_PackageConflict(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for testing
+	// only conflict testing
+	const pathConflict = "abc.xy/pkg/conflict"
+	cachepath.Set(pathConflict)
+
+	t.Run("root package conflict", func(t *testing.T) {
+		t.Parallel()
+
+		resolver := NewRootResolver("./testdata")
+		loader := NewLoader(resolver)
+
+		_, err := loader.Resolve(pathConflict)
+		require.Error(t, err)
+		require.Equal(t, "Root package conflict in "+pathConflict, err.Error())
+	})
+	t.Run("no root package conflict", func(t *testing.T) {
+		t.Parallel()
+
+		resolver := NewRootResolver("./testdata")
+		loader := NewLoader(resolver)
+
+		_, err := loader.Resolve(TestdataPkgA)
+		require.NoError(t, err)
+	})
+
 }

--- a/contribs/gnodev/pkg/packages/loader_test.go
+++ b/contribs/gnodev/pkg/packages/loader_test.go
@@ -3,7 +3,7 @@ package packages
 import (
 	"testing"
 
-	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/contribs/gnodev/pkg/packages/loader_test.go
+++ b/contribs/gnodev/pkg/packages/loader_test.go
@@ -3,7 +3,7 @@ package packages
 import (
 	"testing"
 
-"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+	"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/contribs/gnodev/pkg/packages/resolver_local.go
+++ b/contribs/gnodev/pkg/packages/resolver_local.go
@@ -1,11 +1,14 @@
 package packages
 
 import (
+	"errors"
 	"fmt"
 	"go/token"
 	"path"
 	"path/filepath"
 	"strings"
+
+	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 )
 
 type LocalResolver struct {
@@ -30,6 +33,9 @@ func (r LocalResolver) IsValid() bool {
 }
 
 func (r LocalResolver) Resolve(fset *token.FileSet, path string) (*Package, error) {
+	if cachepath.Get(path) {
+		return nil, errors.New("Local package conflict in " + path)
+	}
 	after, found := strings.CutPrefix(path, r.Path)
 	if !found {
 		return nil, ErrResolverPackageNotFound

--- a/contribs/gnodev/pkg/packages/resolver_local.go
+++ b/contribs/gnodev/pkg/packages/resolver_local.go
@@ -7,8 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-
-	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+ "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 )
 
 type LocalResolver struct {

--- a/contribs/gnodev/pkg/packages/resolver_local.go
+++ b/contribs/gnodev/pkg/packages/resolver_local.go
@@ -7,7 +7,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
- "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+
+	"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 )
 
 type LocalResolver struct {

--- a/contribs/gnodev/pkg/packages/resolver_remote.go
+++ b/contribs/gnodev/pkg/packages/resolver_remote.go
@@ -9,6 +9,7 @@ import (
 	gopath "path"
 	"strings"
 
+	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -34,6 +35,9 @@ func (res *remoteResolver) Name() string {
 
 func (res *remoteResolver) Resolve(fset *token.FileSet, path string) (*Package, error) {
 	const qpath = "vm/qfile"
+	if cachepath.Get(path) {
+		return nil, errors.New("Remote package conflict in " + path)
+	}
 
 	// First query files
 	data := []byte(path)

--- a/contribs/gnodev/pkg/packages/resolver_remote.go
+++ b/contribs/gnodev/pkg/packages/resolver_remote.go
@@ -9,7 +9,7 @@ import (
 	gopath "path"
 	"strings"
 
-	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+ "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/std"

--- a/contribs/gnodev/pkg/packages/resolver_remote.go
+++ b/contribs/gnodev/pkg/packages/resolver_remote.go
@@ -9,7 +9,7 @@ import (
 	gopath "path"
 	"strings"
 
- "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+	"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/std"

--- a/contribs/gnodev/pkg/packages/resolver_root.go
+++ b/contribs/gnodev/pkg/packages/resolver_root.go
@@ -1,10 +1,13 @@
 package packages
 
 import (
+	"errors"
 	"fmt"
 	"go/token"
 	"os"
 	"path/filepath"
+
+	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 )
 
 type rootResolver struct {
@@ -25,6 +28,11 @@ func (r *rootResolver) Name() string {
 }
 
 func (r *rootResolver) Resolve(fset *token.FileSet, path string) (*Package, error) {
+
+	if cachepath.Get(path) {
+		return nil, errors.New("Package conflict root in " + path)
+	}
+
 	dir := filepath.Join(r.root, path)
 	_, err := os.Stat(dir)
 	if err != nil {

--- a/contribs/gnodev/pkg/packages/resolver_root.go
+++ b/contribs/gnodev/pkg/packages/resolver_root.go
@@ -28,9 +28,8 @@ func (r *rootResolver) Name() string {
 }
 
 func (r *rootResolver) Resolve(fset *token.FileSet, path string) (*Package, error) {
-
 	if cachepath.Get(path) {
-		return nil, errors.New("Package conflict root in " + path)
+		return nil, errors.New("Root package conflict in " + path)
 	}
 
 	dir := filepath.Join(r.root, path)

--- a/contribs/gnodev/pkg/packages/resolver_root.go
+++ b/contribs/gnodev/pkg/packages/resolver_root.go
@@ -6,7 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
-cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+	"github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 )
 
 type rootResolver struct {

--- a/contribs/gnodev/pkg/packages/resolver_root.go
+++ b/contribs/gnodev/pkg/packages/resolver_root.go
@@ -6,8 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
-
-	cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
+cachepath "github.com/gnolang/gno/contribs/gnodev/pkg/cachepath"
 )
 
 type rootResolver struct {


### PR DESCRIPTION
feat(gnodev) cache path and notify conflict path 
it resolves issue #4197

- Cache a list of manually added AddPkg messages from the user.
- Return an error and the conflicting path if there is a path conflict.

<!-- please provide a detailed description of the changes made in this
pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is
self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message
was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated
graphs](https://gnoland.github.io/benchmarks), if any. More info
[here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>